### PR TITLE
Add new IDE releases support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = properties("pluginSinceBuild")
+            untilBuild = properties("pluginUntilBuild")
         }
     }
 
@@ -117,7 +118,7 @@ intellijPlatform {
                 types = listOf(IntelliJPlatformType.WebStorm)
                 channels = listOf(ProductRelease.Channel.RELEASE)
                 sinceBuild = properties("pluginSinceBuild")
-                untilBuild = "252.*"
+                untilBuild = properties("pluginUntilBuild")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,11 @@ pluginGroup = com.github.aleksandrsl.intellijluau
 pluginName = Luau
 pluginRepositoryUrl = https://github.com/AleksandrSl/intellij-luau
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.0-eap
+pluginVersion = 0.1.1-eap
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242
+pluginUntilBuild = 252.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
Since the 2025.2 update the plugin was disabled due to old version:
Plugin 'Luau' (version '0.1.0-eap') is not compatible with the current version of the IDE, because it requires build 251.* or older but the current build is IU-252.23892.409